### PR TITLE
add: .gitignore to prevent large Terraform provider files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Terraform files
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate*
+
+# Minikube tunnel files
+tunnel.log
+tunnel.pid
+
+# Port-forward files
+*-pf.log
+*-pf.pid
+
+# Temporary files
+*.log
+*.tmp
+*.temp
+.DS_Store
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS generated files
+Thumbs.db
+.directory
+
+# Backup files
+*~
+*.bak
+*.backup
+
+# Git Large File Storage
+*.lfs


### PR DESCRIPTION
- Exclude terraform/.terraform/ directory
- Prevent 50MB+ provider files from being committed
- Add common ignore patterns for logs, temp files, IDE files